### PR TITLE
Ci fix (temporary)

### DIFF
--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -21,7 +21,6 @@ jobs:
         with:
           activate-environment: test
           environment-file: requirements.txt
-          python-version: 3.8
           auto-activate-base: false
           channels: conda-forge
       - shell: bash -l {0}

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pydicom
 pyMapVBVD>=0.4.0
 scipy
 brukerapi>=0.1.4.0
+pandas

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ pydicom
 pyMapVBVD>=0.4.0
 scipy
 brukerapi>=0.1.4.0
-pandas


### PR DESCRIPTION
The CI build fails due to the latest v2.1.0 release of setup-miniconda.

Example build failure: https://github.com/wexeee/spec2nii/runs/2235588308?check_suite_focus=true

Two solutions for push_pr.yml:

1. Pin setup-miniconda version to v2.0.1
2. Remove pinned Python version for v2.1.0 (workaround)
   - conda-incubator/setup-miniconda#158 (comment)

Note that there might also be a channel ordering issue conda-incubator/setup-miniconda#160